### PR TITLE
More options for hdr.boxplot

### DIFF
--- a/R/hdr.R
+++ b/R/hdr.R
@@ -234,7 +234,7 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 #' @param pch Plotting character.
 #' @export
 hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), lambda=1, boxlabels="", col= gray((9:1)/10),
-    main = "", xlab="",ylab="", pch=1, border=1,outline=T,space=.25,...)
+    main = "", xlab="",ylab="", pch=1, border=1,outline=TRUE,space=.25,...)
 {
     if(!is.list(x))
         x <- list(x)

--- a/R/hdr.R
+++ b/R/hdr.R
@@ -229,11 +229,12 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 #' @rdname hdr
 #' @param boxlabels Label for each box plotted.
 #' @param outline If ‘outline’ is not true, the outliers are not drawn .
+#' @param space The space beetwen each box, between 0 and .5.
 #' @param main Overall title for the plot.
 #' @param pch Plotting character.
 #' @export
 hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), lambda=1, boxlabels="", col= gray((9:1)/10),
-    main = "", xlab="",ylab="", pch=1, border=1,outline=T,...)
+    main = "", xlab="",ylab="", pch=1, border=1,outline=T,space=.25,...)
 {
     if(!is.list(x))
         x <- list(x)
@@ -266,7 +267,8 @@ hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), 
             endsi <- ends[[i]]
             for(k in 1:(length(endsi)/2))
             {
-                polygon( c(j-0.25,j-0.25,j+0.25,j+0.25,j-0.25),
+                sp=.5-space
+                polygon( c(j-sp,j-sp,j+sp,j+sp,j-sp),
                     c(endsi[k*2-1],endsi[k*2],
                     endsi[k*2],endsi[k*2-1],endsi[k*2-1]),
                     col =cols[i], border=border)

--- a/R/hdr.R
+++ b/R/hdr.R
@@ -228,6 +228,7 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 
 #' @rdname hdr
 #' @param boxlabels Label for each box plotted.
+#' @param outline If ‘outline’ is not true, the outliers are not drawn .
 #' @param main Overall title for the plot.
 #' @param pch Plotting character.
 #' @export

--- a/R/hdr.R
+++ b/R/hdr.R
@@ -232,7 +232,7 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 #' @param pch Plotting character.
 #' @export
 hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), lambda=1, boxlabels="", col= gray((9:1)/10),
-    main = "", xlab="",ylab="", pch=1,  ...)
+    main = "", xlab="",ylab="", pch=1, border=1 ...)
 {
     if(!is.list(x))
         x <- list(x)
@@ -268,7 +268,7 @@ hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), 
                 polygon( c(j-0.25,j-0.25,j+0.25,j+0.25,j-0.25),
                     c(endsi[k*2-1],endsi[k*2],
                     endsi[k*2],endsi[k*2-1],endsi[k*2-1]),
-                    col =cols[i])
+                    col =cols[i], border=border)
             }
         }
         for(k in 1:length(ends$mode))

--- a/R/hdr.R
+++ b/R/hdr.R
@@ -232,7 +232,7 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 #' @param pch Plotting character.
 #' @export
 hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), lambda=1, boxlabels="", col= gray((9:1)/10),
-    main = "", xlab="",ylab="", pch=1, border=1,...)
+    main = "", xlab="",ylab="", pch=1, border=1,outline=T,...)
 {
     if(!is.list(x))
         x <- list(x)
@@ -273,8 +273,10 @@ hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), 
         }
         for(k in 1:length(ends$mode))
             lines(c(j-0.35,j+0.35),rep(ends$mode[k],2),lty=1)
-        outliers <- xx[xx<min(ends[[1]]) | xx>max(ends[[1]])]
-        points(rep(j,length(outliers)),outliers,pch=pch)
+        if(outline){
+            outliers <- xx[xx<min(ends[[1]]) | xx>max(ends[[1]])]
+            points(rep(j,length(outliers)),outliers,pch=pch)
+        }
     }
     invisible()
 }

--- a/R/hdr.R
+++ b/R/hdr.R
@@ -232,7 +232,7 @@ hdr.den <- function(x, prob=c(50,95,99), den, h=hdrbw(BoxCox(x,lambda),mean(prob
 #' @param pch Plotting character.
 #' @export
 hdr.boxplot <- function(x, prob=c(99,50), h=hdrbw(BoxCox(x,lambda),mean(prob)), lambda=1, boxlabels="", col= gray((9:1)/10),
-    main = "", xlab="",ylab="", pch=1, border=1 ...)
+    main = "", xlab="",ylab="", pch=1, border=1,...)
 {
     if(!is.list(x))
         x <- list(x)


### PR DESCRIPTION
I wanted to draw some graph similar to the figure 4 in Hyndman 96:
![image](https://user-images.githubusercontent.com/4749455/40575550-48634172-60e7-11e8-8251-5bd6acba7dcf.png)
  
I could have done it manually, using the results of `hdr` to draw the polygons, but I though that maybe well done by modifying a bit the function `hdr.boxplot`.

I wrote a simple minimodel of growth to illustrate it:

```R
library(scales)

#simple exponentail growth
growth <- function(startsize,numyear,range){
       pop=startsize
       rate=runif(numyear,range[1],range[2])
       for(i in 1:numyear){
           pop=c(pop,pop[i]+rate[i]*pop[i])
       }
       return(pop)
}

#return a random number randomly choosen from two normal distrbution
nmodal <- function(n,mean,sd){
    i=sample(length(mean),1)
    return(rnorm(n,mean[i],sd[i]))
}
alltraj=sapply(1:100000,function(x)growth(nmodal(1,c(35,60),c(5,5)),150,c(0,0.05)))
talltraj=t(alltraj)
lstraj=split(talltraj,rep(1:ncol(talltraj),each = nrow(talltraj)))
hdr.boxplot(lstraj[1:150],prob=c(50,90),border=NA,pch=".",outline=F,col=c("khaki","dark orange"),main="Exp. growth",space=0,ylim=c(0,3000))
```

The result of this small script :

![image](https://user-images.githubusercontent.com/4749455/40575866-49b63ae2-60ed-11e8-8804-9ff333ff2f77.png)

