### PR TITLE
minor fix

### DIFF
--- a/R/hdr.boxplot.2d.R
+++ b/R/hdr.boxplot.2d.R
@@ -118,7 +118,7 @@ plot.hdr2d <- function(x, shaded=TRUE, show.points=FALSE, outside.points=FALSE, 
     index <- (x$fxy < 0.99999*min(x$falpha))
     points(x$x[index], x$y[index], pch=pch, col=pointcol)
   }
-  points(x$mode[1],x$mode[2],pch=19,col="black")
+  points(x$mode[1],x$mode[2],pch=19,col=pointcol)
   invisible(x)
 }
 

--- a/R/hdr.boxplot.2d.R
+++ b/R/hdr.boxplot.2d.R
@@ -87,12 +87,12 @@ hdr.2d <- function(x, y, prob = c(50, 95, 99), den=NULL, kde.package=c("ash","ks
 #' @export hdr.boxplot.2d
 hdr.boxplot.2d <- function(x, y, prob=c(50, 99), kde.package=c("ash","ks"), h=NULL,
   xextend=0.15, yextend=0.15, xlab="", ylab="",
-  shadecols=gray((length(prob):1)/(length(prob)+1)), pointcol=1, ...)
+  shadecols=gray((length(prob):1)/(length(prob)+1)), pointcol=1,  outside.points=TRUE,...)
 {
   # Estimate bivariate density
   hdr <- hdr.2d(x, y, prob=prob, kde.package=kde.package, h=h, xextend=xextend, yextend=yextend)
   # Produce plot
-  plot(hdr, xlab=xlab, ylab=ylab, shadecols=shadecols, pointcol=pointcol, outside.points=TRUE,...)
+  plot(hdr, xlab=xlab, ylab=ylab, shadecols=shadecols, pointcol=pointcol, outside.points=outside.points,...)
 }
 
 #' @param shaded If \code{TRUE}, the HDR contours are shown as shaded regions.


### PR DESCRIPTION
Minor bug fix: 

e433761 : the color of the point used to represent the mode was alwasy using "black",  it was impossible to modify it using `pointcol`. 

b1882e5 : it was impossible to pass `outside.points=FALSE` to `hdr.boxplot.2d` as it was conflicting with its call afterward `plot(hdr,...)`.